### PR TITLE
Detect secret PBs by checking if the time below is secret

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -74,6 +74,10 @@ void PBLoop()
             {
                 WebhookSettings::webhooks[i].UpdatePosition(map, previousScore);
             }
+
+            // pre-check if the time below our pb is secret to work around the 'barely pbed' issue noted in IsLeaderboardTimeBelowSecret
+            Leaderboard::IsLeaderboardTimeBelowSecret(map.Uid, previousScore);
+            
             continue;
         }
 

--- a/src/Networking/Leaderboard.as
+++ b/src/Networking/Leaderboard.as
@@ -1,0 +1,44 @@
+namespace Leaderboard {
+    bool storedKnownSecretThreshold = false;
+    uint knownSecretThreshold;
+    string knownSecretThresholdMapUid;
+
+    bool IsLeaderboardTimeBelowSecret(string mapUid, uint score) {
+        if (score == -1)
+            return false;
+
+        if (storedKnownSecretThreshold) {
+            if (mapUid == knownSecretThresholdMapUid) {
+                if (score < knownSecretThreshold) {
+                    return true;
+                }
+            } else {
+                // changed map, reset stored threshold
+                storedKnownSecretThreshold = false;
+            }
+        }
+
+        Json::Value@ surroundRes = Nadeo::LiveServiceRequest("/api/token/leaderboard/group/Personal_Best/map/" + mapUid + "/surround/0/1?score=" + score + "onlyWorld=true");
+        try {
+            Json::Value@ surrounding = surroundRes["tops"][0]["top"];
+
+            if (surrounding.Length != 2) {
+                // the surround endpoint returns a fake entry at the requested time drove by us
+                // if we just barely pbed such that our previous pb is the time below it, then only the one new fake entry will be returned, so we can't know if it's secret, since there's no time below it to check with
+                return false;
+            }
+            
+            if (surrounding[1]["score"] == -1) {
+                storedKnownSecretThreshold = true;
+                knownSecretThresholdMapUid = mapUid;
+                knownSecretThreshold = score;
+                return true;
+            }
+        } catch {
+            Log("Error when fetching surrounding records: " + getExceptionInfo());
+        }
+
+        return false;
+    }
+}
+

--- a/src/PB/PB.as
+++ b/src/PB/PB.as
@@ -13,9 +13,22 @@ class PB
         Medal = Medal::GetReachedMedal(Map, score);
         PreviousScore = previousScore;
         _score = score;
-        Score = (score <= Map.AuthorMedalTime && Campaign::WeeklyShorts.IsCurrentCampaignMap(map)) ? -1 : score;
+        Score = IsSecretTime(map, score) ? -1 : score;
     }
 
+    private bool IsSecretTime(Map@ map, uint score)
+    {
+        if (score <= Map.AuthorMedalTime && Campaign::WeeklyShorts.IsCurrentCampaignMap(map))
+            return true;
+
+        // seemingly there's no nice global way of determining whether your pb is secret. if a record belongs to the authenticated account, the time is revealed.
+        // to work around that, check if the time below our pb is secret. if yes, then ours is too
+        if (Leaderboard::IsLeaderboardTimeBelowSecret(map.Uid, score))
+            return true;
+
+        return false;
+    }
+    
     private void SetPBPosition(const string &in mapUid, uint time)
     {
         Json::Value@ requestbody = Json::Object();


### PR DESCRIPTION
Addresses https://github.com/FabianvZ/TrackmaniaClubHook/issues/12

This detects whether times are secret by querying the leaderboard for the next slowest record, and uses whether that record has a secret time or not to determine whether yours will be too.

I'm not entirely sure if this is the most "correct" way of solving this issue, but there doesn't seem to be a clean solution. You can see [the issue](https://github.com/FabianvZ/TrackmaniaClubHook/issues/12) for more discussion on this. This approach does have edge cases where it won't work, like if you're the slowest secret record on a map, but I couldn't come up with anything better.